### PR TITLE
Get highest resolution YouTube background image

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -322,7 +322,7 @@
 
 		if (!data.posterLoaded) {
 			if (!data.source.poster) {
-				data.source.poster = "http://img.youtube.com/vi/" + data.videoId + "/0.jpg";
+				data.source.poster = "http://img.youtube.com/vi/" + data.videoId + "/maxresdefault.jpg";
 			}
 
 			data.posterLoaded = true;


### PR DESCRIPTION
The default 0.jpg image served from YouTube is very small.
maxresdefault.jpg gets the highest resolution possible:

http://img.youtube.com/vi/[video-id]/0.jpg
http://img.youtube.com/vi/[video-id]/1.jpg
http://img.youtube.com/vi/[video-id]/2.jpg
http://img.youtube.com/vi/[video-id]/3.jpg
http://img.youtube.com/vi/[video-id]/maxresdefault.jpg
